### PR TITLE
Updated services to new repositories

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,29 +15,32 @@ services:
       SPARQL_UPDATE: "true"
       DEFAULT_GRAPH: "http://mu.semte.ch/application"
   event-query:
-    image: bde2020/mu-docker-event-query
+    image: bde2020/mu-event-query-service
     links:
       - database:database
     volumes:
       - ./containers:/usr/src/app/containers/
-      - ./mu-docker-event-query/src:/app/
     environment:
       SLEEP_PERIOD: '10'
   har-transformation:
-    image: bde2020/mu-har-transformation
+    image: bde2020/mu-har-transformation-service
     volumes:
       - ./pcap:/app/pcap
       - ./har:/app/har
       - ./containers:/app/containers
+      - ./backups:/app/backups
     links:
       - elasticsearch:elasticsearch
+    environment:
+      BU_DIR: "/app/backups"
   elasticsearch:
-    image: elasticsearch:2
-    command: elasticsearch -Des.network.host=0.0.0.0
+    image: elasticsearch:5.5.0
+    # build: ../docker-elasticsearch
+    command: elasticsearch -E network.host=0.0.0.0
     ports:
       - "9200:9200"
   kibana:
-    image: kibana:4
+    image: kibana:5.5
     ports:
       - "5601:5601"
     environment:


### PR DESCRIPTION
After updating it, now ElasticSearch will break unless you do

```
sudo sysctl -w vm.max_map_count=262144
```
before running it